### PR TITLE
Fixes s3-bucket-name invalid error

### DIFF
--- a/infrastructure/internals/terraform/terraform.go
+++ b/infrastructure/internals/terraform/terraform.go
@@ -65,8 +65,8 @@ func getTerraformOutput(workspaceDir string) (string, error) {
 	cmd.Dir = workspaceDir
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 	err := cmd.Run()
 
 	if err != nil {


### PR DESCRIPTION
**Changes**
- pointing to buffer stdout instead of os.Stdout